### PR TITLE
neovimの設定を修正

### DIFF
--- a/packages/neovim/.config/nvim/init.lua
+++ b/packages/neovim/.config/nvim/init.lua
@@ -1,5 +1,7 @@
 local cmd = vim.cmd
 
+if vim.fn.has('nvim') == 1 then
 cmd('source ' .. '~/dotfiles/packages/vim/.vim/basic.vim')
+end
 
 require('lazy_nvim')

--- a/packages/neovim/.config/nvim/lua/config/lspconfig.lua
+++ b/packages/neovim/.config/nvim/lua/config/lspconfig.lua
@@ -57,6 +57,18 @@ vim.api.nvim_create_autocmd('LspAttach', {
   end
 })
 
+
+-- Autocomplete keybindings
+local cmp = require('cmp')
+local cmp_action = require('lsp-zero').cmp_action()
+
+cmp.setup({
+  mapping = cmp.mapping.preset.insert({
+    -- `Enter` key to confirm completion
+    ['<CR>'] = cmp.mapping.confirm({select = false}),
+  })
+})
+
 lspconfig.tsserver.setup({})
 lspconfig.eslint.setup({})
 lsp.setup()

--- a/packages/neovim/.config/nvim/lua/config/telescope.lua
+++ b/packages/neovim/.config/nvim/lua/config/telescope.lua
@@ -2,6 +2,7 @@ local opts = { noremap=true, silent=true }
 local builtin = require('telescope.builtin')
 
 vim.keymap.set('n', '<leader>ff', builtin.find_files, opts)
+vim.keymap.set('n', '<leader>fa', '<CMD>Telescope find_files hidden=true <CR>', opts)
 vim.keymap.set('n', '<leader>fg', builtin.live_grep, opts)
 vim.keymap.set('n', '<leader>fb', builtin.buffers, opts)
 vim.keymap.set('n', '<leader>fh', builtin.help_tags, opts)

--- a/packages/vim/.vim/basic.vim
+++ b/packages/vim/.vim/basic.vim
@@ -38,7 +38,7 @@ let &t_SI.= "\e[6 q"
 set number
 set relativenumber
 set foldcolumn=0
-set signcolumn=number
+" set signcolumn=number
 
 " ステータスライン
 let g:lightline = {


### PR DESCRIPTION
## 変更点
- basic.vimの読み込む条件にnvimであることを追加
- telescopeで隠しファイルを検索できるキーバインドを追加
- lsp-zeroでサジェストが表示されるフローティングウィンドウ上で決定ボタンを`enter`も反応するように変更