### PR TITLE
プラグインsheerun/vim-polyglotを追加

### DIFF
--- a/packages/neovim/.config/nvim/lua/plugins.lua
+++ b/packages/neovim/.config/nvim/lua/plugins.lua
@@ -44,6 +44,8 @@ return {
   'tpope/vim-commentary',
   'tpope/vim-surround',
 
+  'sheerun/vim-polyglot',
+
   {
     "folke/which-key.nvim",
     lazy = true


### PR DESCRIPTION
https://github.com/sheerun/vim-polyglot

## 症状
vueファイルで行数が多い場合にシンタックスハイライトが当たらない

## 追加理由
様々な形式のシンタックスハイライトをまとめたライブリラリを入れることで症状が改善する

[参考サイト](https://maguro.dev/vim-polyglot-for-highlight/)