### PR TITLE
neovim プラグイン変更

### DIFF
--- a/packages/neovim/.config/nvim/init.lua
+++ b/packages/neovim/.config/nvim/init.lua
@@ -1,3 +1,5 @@
+vim.loader.enable()
+
 local cmd = vim.cmd
 
 if vim.fn.has('nvim') == 1 then

--- a/packages/neovim/.config/nvim/lua/plugins.lua
+++ b/packages/neovim/.config/nvim/lua/plugins.lua
@@ -21,8 +21,26 @@ return {
   -- auto tag pairs
   'jiangmiao/auto-pairs',
 
+  -- indent
+  'Yggdroot/indentLine',
   -- git
-  'tpope/vim-fugitive',
+  {
+    'dinhhuy258/git.nvim',
+    config = function ()
+      require('git').setup({
+        -- NOTE: `quit_blame` and `blame_commit` are still merged to the keymaps even if `default_mappings = false`
+        default_mappings = true,
+
+        keymaps = {
+          -- Open blame commit
+          diff = "<Leader>gd",
+          -- Close git diff
+          diff_close = "<Leader>gD",
+        },
+      })
+    end
+  },
+
   {
     'lewis6991/gitsigns.nvim',
     config = function()
@@ -202,7 +220,7 @@ return {
   -- fzf
   {
     'nvim-telescope/telescope.nvim',
-    tag = '0.1.1',
+    tag = '0.1.4',
     dependencies = { 'nvim-lua/plenary.nvim' },
     config = function()
       require('config/telescope')

--- a/packages/vim/.vim/basic.vim
+++ b/packages/vim/.vim/basic.vim
@@ -21,9 +21,11 @@ command! FZFFileList call fzf#run({
 let NERDTreeShowHidden = 1
 :noremap <C-n> :NERDTreeToggle<CR>
 
-" vim-fugitive キーマップ
-nnoremap <leader>d :<C-u>Gdiff<CR>
-nnoremap <leader>r :<C-u>Git blame<CR>
+" インデントの文字
+let g:indentLine_char_list = ['┊']
+
+" git.nvim キーマップ
+nnoremap <leader>r :<C-u>GitBlame<CR>
 
 " vim-gitgutter
 "変更点表示の時間を設定

--- a/packages/vim/.vimrc
+++ b/packages/vim/.vimrc
@@ -43,4 +43,8 @@ if len(s:removed_plugins) > 0
   call dein#recache_runtimepath()
 endif
 
+" vim-fugitive キーマップ
+nnoremap <leader>d :<C-u>Gdiff<CR>
+nnoremap <leader>r :<C-u>Git blame<CR>
+
 execute 'source' '~/dotfiles/packages/vim/.vim/basic.vim'


### PR DESCRIPTION
- インデントを可視化するプラグインを追加
- neovim上からのgit操作するためのプラグインをnvim専用のものに変更
- telescopeでバグが発生したためバージョンアップ[参考](https://github.com/nvim-telescope/telescope.nvim/issues/2735)