### PR TITLE
neovim プラグインgit.nvimのlazyオプションを削除

### DIFF
--- a/packages/neovim/.config/nvim/lua/plugins.lua
+++ b/packages/neovim/.config/nvim/lua/plugins.lua
@@ -27,7 +27,6 @@ return {
   -- git
   {
     'dinhhuy258/git.nvim',
-    lazy = true,
     config = function ()
       require('git').setup({
         -- NOTE: `quit_blame` and `blame_commit` are still merged to the keymaps even if `default_mappings = false`


### PR DESCRIPTION
lazyオプションがtrueだとプラグインが読み込まれずに動作しないためlazyオプションを削除